### PR TITLE
ADD - new auditor events

### DIFF
--- a/packages/tongo-sdk/src/data.service.ts
+++ b/packages/tongo-sdk/src/data.service.ts
@@ -40,6 +40,8 @@ interface BaseEvent {
     type: ReaderEventType;
     tx_hash: string;
     block_number: number;
+    event_index: number;
+    transaction_index: number;
 }
 
 interface FundEventData {


### PR DESCRIPTION
Auditors now can

    Get the last auditor event emitted for a user.
    Get the "real" balance for a user, last declaredBalance + all incoming transfers after the declaration.
    Get all the auditor events emitted associated with a specific tx hash.