### PR TITLE
fix: correct broken import paths in prover modules

### DIFF
--- a/packages/tongo-sdk/package.json
+++ b/packages/tongo-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fatsolutions/tongo-sdk",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "An SDK for interacting with Tongo contracts",
   "homepage": "https://github.com/fatlabsxyz/tongo",
   "repository": {

--- a/packages/tongo-sdk/src/provers/audit.ts
+++ b/packages/tongo-sdk/src/provers/audit.ts
@@ -2,7 +2,7 @@ import { compute_challenge, compute_s, generateRandom } from "@fatsolutions/she"
 import { SameEncryptUnknownRandom } from "@fatsolutions/she/protocols";
 import { GENERATOR as g } from "../constants";
 import { CipherBalance, ProjectivePoint, GeneralPrefixData, compute_prefix } from "../types";
-import { createCipherBalance} from "../../src/utils";
+import { createCipherBalance} from "../utils";
 
 // cairo string 'audit'
 export const AUDIT_CAIRO_STRING = 418581342580n;

--- a/packages/tongo-sdk/src/provers/fund.ts
+++ b/packages/tongo-sdk/src/provers/fund.ts
@@ -2,7 +2,7 @@ import { compute_challenge } from "@fatsolutions/she";
 import { poe } from "@fatsolutions/she/protocols";
 
 import { GENERATOR as g } from "../constants";
-import { createCipherBalance} from "../../src/utils";
+import { createCipherBalance} from "../utils";
 import { ProjectivePoint, GeneralPrefixData, CipherBalance, compute_prefix } from "../types";
 
 

--- a/packages/tongo-sdk/src/provers/ragequit.ts
+++ b/packages/tongo-sdk/src/provers/ragequit.ts
@@ -2,7 +2,7 @@ import { poe } from "@fatsolutions/she/protocols";
 
 import { GENERATOR as g } from "../constants";
 import { CipherBalance, compute_prefix, GeneralPrefixData, ProjectivePoint } from "../types";
-import { createCipherBalance} from "../../src/utils";
+import { createCipherBalance} from "../utils";
 
 import { compute_challenge, compute_s, generateRandom } from "@fatsolutions/she";
 

--- a/packages/tongo-sdk/src/provers/transfer.ts
+++ b/packages/tongo-sdk/src/provers/transfer.ts
@@ -5,7 +5,7 @@ import { range as SHE_range} from "@fatsolutions/she/protocols"
 import { GENERATOR as g, SECONDARY_GENERATOR as h } from "../constants";
 import { generateRangeProof, Range, verifyRangeProof } from "../provers/range";
 import { CipherBalance, compute_prefix,  GeneralPrefixData, ProjectivePoint } from "../types";
-import { createCipherBalance} from "../../src/utils";
+import { createCipherBalance} from "../utils";
 
 // cairo string 'transfer'
 export const TRANSFER_CAIRO_STRING = 8390876182755042674n;

--- a/packages/tongo-sdk/src/provers/withdraw.ts
+++ b/packages/tongo-sdk/src/provers/withdraw.ts
@@ -5,7 +5,7 @@ import { range as SHE_range} from "@fatsolutions/she/protocols"
 import { GENERATOR as g, SECONDARY_GENERATOR as h } from "../constants";
 import { generateRangeProof, Range, verifyRangeProof } from "../provers/range";
 import { CipherBalance, compute_prefix, GeneralPrefixData, ProjectivePoint } from "../types";
-import { createCipherBalance} from "../../src/utils";
+import { createCipherBalance} from "../utils";
 
 // cairo string 'withdraw'
 export const WITHDRAW_CAIRO_STRING = 8604536554778681719n;


### PR DESCRIPTION
## Summary

- Fix broken `../../src/utils` import paths in all 5 prover modules (audit, fund, ragequit, transfer, withdraw)
- The correct relative path from `src/provers/` to `src/utils` is `../utils`, not `../../src/utils`
- The old path works at source level (goes up to package root then back into `src/`) but breaks in the `dist/` build output because `dist/provers/*.js` resolves `../../src/utils` to a non-existent path
- This makes the published npm package (`@fatsolutions/tongo-sdk@1.3.0` and `1.3.1`) crash at import time with `Cannot find module '../../src/utils'`
- Bumps version to 1.3.2

## Test plan

- [x] `pnpm run build` succeeds with no broken paths in `dist/`
- [x] All 13 unit tests pass
- [x] Verified `dist/provers/*.js` files now use `require("../utils")` instead of `require("../../src/utils")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)